### PR TITLE
feature: allow flashing of uf2s with non-contiguous blocks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,83 @@
+name: CMake
+
+on:
+  push:
+    branches:
+      - non-contiguous-uf2
+  pull_request:
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    name: Build UF2 artifacts (pico2)
+    runs-on: ubuntu-latest
+
+    env:
+      PICO_SDK_PATH: ${{github.workspace}}/pico-sdk
+
+    steps:
+    - name: Compiler Cache
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/.ccache
+        key: ccache-cmake-${{github.ref}}-${{github.sha}}
+        restore-keys: |
+          ccache-cmake-${{github.ref}}
+          ccache-cmake
+
+    - name: Checkout Code
+      uses: actions/checkout@v4
+      with:
+        path: src
+        submodules: recursive
+
+    - name: Checkout Pico SDK
+      uses: actions/checkout@v4
+      with:
+        ref: '2.2.0'
+        repository: raspberrypi/pico-sdk
+        path: pico-sdk
+        submodules: true
+
+    - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)
+      uses: carlosperate/arm-none-eabi-gcc-action@v1
+      with:
+        release: '13.3.Rel1'
+
+    - name: Install CCache
+      run: sudo apt update && sudo apt install -y ccache
+
+    - name: Configure CMake
+      run: |
+        cmake -E make_directory ${{runner.workspace}}/build
+        cmake -S ${{github.workspace}}/src -B ${{runner.workspace}}/build \
+          -DPICO_SDK_PATH=${{github.workspace}}/pico-sdk \
+          -DPICO_BOARD=pico2 \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      run: |
+        ccache --zero-stats || true
+        cmake --build . --config $BUILD_TYPE -j$(nproc)
+        ccache --show-stats || true
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: uf2loader-pico2
+        path: ${{runner.workspace}}/output/*.uf2
+
+    # ── Update rolling latest release ────────────────────────────────────────
+    - name: Update latest release
+      if: github.event_name == 'push' && github.ref == 'refs/heads/non-contiguous-uf2'
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: latest
+        name: Latest Build
+        prerelease: true
+        make_latest: 'true'
+        files: ${{runner.workspace}}/output/*.uf2

--- a/ui/uf2.c
+++ b/ui/uf2.c
@@ -100,8 +100,8 @@ static inline int FLASH_ERASE(uintptr_t address, uint32_t size_bytes)
                                  (CFLASH_SECLEVEL_VALUE_SECURE << CFLASH_SECLEVEL_LSB) |
                                  (CFLASH_ASPACE_VALUE_RUNTIME << CFLASH_ASPACE_LSB)};
 
-  // Round up size_bytes or rom_flash_op will throw an alignment error
-  uint32_t size_aligned = (size_bytes + 0x1FFF) & -FLASH_SECTOR_SIZE;
+  // Round up size_bytes to the next sector boundary
+  uint32_t size_aligned = (size_bytes + FLASH_SECTOR_SIZE - 1) & -FLASH_SECTOR_SIZE;
 
   return rom_flash_op(cflash_flags, address, size_aligned, NULL);
 }
@@ -238,7 +238,7 @@ enum uf2_result_e __attribute__((optimize("-O0"))) load_application_from_uf2(con
 
       if (ensure_sector_erased(b->target_addr) < 0)
       {
-        DEBUG_PRINT("Erase failed for block %d\n", b->block_no);
+        DEBUG_PRINT("Erase failed for block %d at address 0x%08x\n", b->block_no, b->target_addr);
         return UF2_UNKNOWN;
       }
 


### PR DESCRIPTION
If you want to flash ZeptoForth via UF2 Loader, it fails because ZeptoForth uses a UF2 format with gaps in it. The address blocks are not contiguous. The current UF2 Loader cannot handle this and fails to flash the UF2.

This also happens with UF2s downloaded via the ZeptoForth `download_uf2_image.sh` script.

With this PR it is possible to flash non-contiguous UF2s via UF2 Loader.

Therefore the flash is not erased upfront, but is instead erased sector by sector in the flash loop. To track whether a sector has already been erased, a bitmap has been added to track the sector state. This way a sector is only erased once, preventing already written blocks in the sector from being overwritten.

**_I tested it only on RP2350_** with various UF2s (WebMite, Logo, Lua, rpngo, and of course ZeptoForth) and it looks promising.
